### PR TITLE
error using encoding keyword on windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 from os import path
 here = path.abspath(path.dirname(__file__))
-with open(path.join(here, 'README.txt'), encoding='utf-8') as f:
+with open(path.join(here, 'README.txt'),'r') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
avoid the error
TypeError: 'encoding' is an invalid keyword argument for this function
