### PR TITLE
added py2.6 +

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,15 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
     long_description=long_description
 )


### PR DESCRIPTION
following the same one as tornado, it was only the 3.x and python 2.x was not in the list, so crawlers will make it incompatible with python 2.
